### PR TITLE
Change version in Makefile + use rs_command_line_worker:0.2.0-ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mediacloudai/rs_command_line_worker:ubuntu-v0.1.7
+FROM mediacloudai/rs_command_line_worker:0.2.0-ubuntu
 
 ENV AMQP_QUEUE job_aws_cli
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ DOCKER_IMG_NAME?=mediacloudai/aws_cli_worker
 ifneq ($(DOCKER_REGISTRY), ) 
 	DOCKER_IMG_NAME := /${DOCKER_IMG_NAME}
 endif
-VERSION="1.0.0"
+VERSION="0.2.0"
 
 ENV?=local
 


### PR DESCRIPTION
Worker will be compliant with ex_backend 0.1.8 & step flow 0.2.1